### PR TITLE
Added support for blocking guiscript via filehooks.

### DIFF
--- a/src/lua/NS2Optimizations/GUIRework/GUIManager.lua
+++ b/src/lua/NS2Optimizations/GUIRework/GUIManager.lua
@@ -93,6 +93,11 @@ local function CreateGUIScript(path)
 		class = _G[script_name]
 	end
 
+	if not class then -- gui script failed to load
+		_G[script_name] = false -- avoid trying to load script another time
+		return
+	end
+
 	local script = class()
 	script:Initialize()
 


### PR DESCRIPTION
Added a check to confirm that the guiscript loaded successfully before initializing it.

Some mods (like Last Stand, Infested) use to just block unnecessary guiscripts from loading via filehooks and thus are not compatible with ns2 optimizations without this change.

Repro:
Just add `ModLoader.SetupFileHook( "lua/GUIWaitingForAutoTeamBalance.lua", "lua/LastStand_FileHooks.lua", "halt" )` to the end of Filehooks.lua 